### PR TITLE
Security fix to avoid arbitrary code execution when using Zarafa database user backend

### DIFF
--- a/README.original
+++ b/README.original
@@ -16,8 +16,7 @@ You may use it in Commercial Zarafa Groupware but for this plugin the License of
 that corresponds to your Commercial Zarafa Groupware applies.
 
 To install it, just copy the content of the passwd-0.99.0.tgz archive into your plugins folder. Please 
-adapt the dialogs/pwdchange.php file according your backend needs (currently zarafa-passwd is in use 
-but taken from /usr/local/bin folder).
+adapt the config.inc.php file according your backend needs.
 
 A word about languages... They're in lang folder defined. I did it for the English and German language.
 Feel free to add your native language. It is not difficult. Just translate the phrases in file and 

--- a/dialogs/pwdchange.php
+++ b/dialogs/pwdchange.php
@@ -130,12 +130,11 @@ function getBody() {
 	else {
 
 		//
-		// use zarafa-admin to change password
+		// use MAPI in SOAP connection to change the password
 		// (this part is basically the original zarafa-passwd
-		// plugin (and really unsecure))
+		// plugin)
 		//
 
-		$passwd_cmd = "/usr/bin/zarafa-passwd -u %s -o %s -p %s";
 		if (
 			($username != null) &&  
 			($password != null) &&  
@@ -145,9 +144,10 @@ function getBody() {
 		) {
 
 			// all information correct, change password
-			$mycmd = sprintf($passwd_cmd, $username, $password, $newpw1);
-			exec($mycmd,$arrayout, $retval);
-			if ($retval == 0) {
+			$store = $GLOBALS['mapisession']->getDefaultMessageStore();
+			$userinfo = mapi_zarafa_getuser_by_name($store, $username);
+
+			if (mapi_zarafa_setuser($store, $userinfo['userid'], $username, $userinfo['fullname'], $userinfo['emailaddress'], $newpw1, 0, $userinfo['admin'])) {
 				echo _("success: password update");
 			} else {
 				echo _("failure: password update");


### PR DESCRIPTION
Without this patch the following works:
- Set $use_ldap in config.inc.php to false
- Logon at Zarafa WebAccess, go to "Settings", choose "Password" tab
- Change the password successfully to e.g. "password; touch /tmp/abc"
- Result: -rw-r--r--. 1 apache apache 0 Feb 14 12:05 /tmp/abc